### PR TITLE
Use clap's SubcommandRequiredElseHelp setting

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -77,6 +77,7 @@ impl<'a, 'b> Cli<'a, 'b> {
                 This app was created as part of an effort to generate \
                 by brute-force billions of melodies, and is tailored for that use case."
             )
+            .setting(clap::AppSettings::SubcommandRequiredElseHelp)
             .subcommand(clap::SubCommand::with_name("single")
                         .about("Generate single MIDI file from provided MIDI pitch sequence")
                         .arg(&note_sequence_argument)
@@ -129,6 +130,7 @@ impl<'a, 'b> Cli<'a, 'b> {
                     matches.subcommand_matches("partition").unwrap(),
                 ))
             },
+            // Unreachable
             Some(directive) => panic!(format!("Received unsupported directive '{}'", directive)),
             None => panic!("Did not receive directive"),
         }


### PR DESCRIPTION
Clap has an app setting (`SubcommandRequiredElseHelp`) to handle applications that require a subcommand present to run.  This commit enables that setting.

This changes the output of when `atm` is run without a subcommand:
Before change:
```
thread 'main' panicked at 'Did not receive directive', src/cli.rs:133:21
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

After change:
```
atm 0.2.0
All The Music, LLC
Tools for generating and working with MIDI files.  This app was created as part of an effort to generate by brute-force
billions of melodies, and is tailored for that use case.

USAGE:
    atm <SUBCOMMAND>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

SUBCOMMANDS:
    batch        Generate by brute-force MIDI files containing permutations of a sequence of MIDI pitches
    help         Prints this message or the help of the given subcommand(s)
    partition    Generate the output path from the 'batch' directive for a given MIDI pitch sequence
    single       Generate single MIDI file from provided MIDI pitch sequence
```

An alternative would be using the `SubcommandRequired` option, which would change the output to:
```
error: 'atm' requires a subcommand, but one was not provided

USAGE:
    atm <SUBCOMMAND>

For more information try --help
```
Although I believe outputting the help message to be the better option in this case.